### PR TITLE
Add c-kzg as a Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "c-kzg-4844"]
+	path = c-kzg-4844
+	url = https://github.com/ethereum/c-kzg-4844.git


### PR DESCRIPTION
Add the `c-kzg-4844` repository as a submodule so that we can generate bitcode for our SAW proofs from the actual source code and not a copy of it.