### PR TITLE
Add BLS Elliptic Curve support in Cryptol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Formal Verification of the c-kzg library: Establishing the Basis
 
 ## Overview
+
 This repository holds the work performed under Grant ID FY24-1544 of the Ethereum Foundation (EF). The purpose of this grant is to explore the viability of using the [Cryptol language](cryptol.net) and the [Software Analysis Workbench (SAW)](https://saw.galois.com) to formally verify the EF's [c-kzg library](https://github.com/ethereum/c-kzg-4844/tree/main) against the [consensus-specs Deneb specification](https://github.com/ethereum/consensus-specs/tree/dev/specs/deneb).

--- a/spec/Common/Utils.cry
+++ b/spec/Common/Utils.cry
@@ -29,26 +29,11 @@ bool_to_bit b = if b == 1 then True else False
 
 /**
  * Exponentiation in the specified modulo field.
- *
  * @see https://github.com/ethereum/c-kzg-4844/blob/main/src/common/fr.c#L93
+ * ```repl
+ * :prove pow`{8} 3 2 7 == 2
+ * :prove pow`{32} 1 18 2 == 1
+ * :prove pow`{256} 0 5 3 == 0
  */
 pow : {n} (fin n, n >= 1) => [n] -> [n] -> [n] -> [n]
 pow base exp modulus = (base ^^ exp) % modulus
-
-/*
- * ===============
- * Unit test suite
- * ===============
- */
-
-/**
- * Unit tests for `pow`.
- * ```repl
- * :prove test_pow`{8} 3 2 7 2
- * :prove test_pow`{32} 1 18 2 1
- * :prove test_pow`{256} 0 5 3 0
- * ```
- */
-test_pow : {n} (fin n, n >= 1) => [n] -> [n] -> [n] -> [n] -> Bit
-property test_pow base exp modulus expected =
-    pow base exp modulus == expected

--- a/spec/Common/Utils.cry
+++ b/spec/Common/Utils.cry
@@ -88,20 +88,22 @@ multinv x m =
  *  i.e. return y such that x * y % modulus == 1
  * Precondition: x != 0
  * ```repl
- * :prove modular_inverse`{32} 7492 319 == 177
+ * :prove modular_inverse 7492 319 == 177
+ * :prove modular_inverse (-3) 319 == 106
  * ```
+ * NOTE: we just chose the values at "random." Checked against: https://planetcalc.com/3298/.
  */
-modular_inverse : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
-modular_inverse x modulus = inverse where
-    inverse = fromInteger (multinv x' modulus')
-    x' = toInteger x
-    modulus' = toInteger modulus
+modular_inverse : Integer -> Integer -> Integer
+modular_inverse x modulus = multinv x' modulus where
+    x' = if x < 0 then x % modulus
+         else x
 
 /**
  * Divide two field elements: x by y
  * ```repl
- * :prov div`{32} 3 7492 319 == 212
+ * :prov div 3 7492 319 == 212
+ * :prov div 3 (-7492) 319 == 107
  * ```
  */
-div : {n} (fin n, n >= 1) => [n] -> [n] -> [n] -> [n]
-div x y modulus = (x * (modular_inverse`{n} y modulus)) % modulus
+div : Integer -> Integer -> Integer -> Integer
+div x y modulus = (x * (modular_inverse y modulus)) % modulus

--- a/spec/Common/Utils.cry
+++ b/spec/Common/Utils.cry
@@ -37,3 +37,71 @@ bool_to_bit b = if b == 1 then True else False
  */
 pow : {n} (fin n, n >= 1) => [n] -> [n] -> [n] -> [n]
 pow base exp modulus = (base ^^ exp) % modulus
+
+/**
+ * Calculates the gcd and Bezout coefficients,
+ *   using the Extended Euclidean Algorithm (recursive).
+ *   (Source: https://extendedeuclideanalgorithm.com/code)
+ * ```repl
+ * :prove xgcd 7 5 1 0 0 1 == (1, -2, 3)
+ * ```
+ */
+xgcd : Integer -> Integer -> Integer -> Integer -> Integer -> Integer -> (Integer, Integer, Integer)
+xgcd a b s1 s2 t1 t2 =
+    if b == 0 then
+        (abs (a), 1, 0)
+    // if r == 0, then b will be the gcd and
+    //    s2, t2 the Bezout coefficients
+    else if r == 0 then
+        (abs (b), fromInteger s2, fromInteger t2)
+    else
+        xgcd b r s2 s3 t2 t3
+    where
+        q = a / b
+        r = a - q * b
+        s3 = s1 - q * s2
+        t3 = t1 - q * t2
+
+/**
+ * Calculates the multiplicative inverse of a number 'x' mod 'm',
+ *  using the Extended Euclidean Algorithm. If 'x' does not have a
+ *  multiplicative inverse mod 'm', then return 0.
+ *  (Source: https://extendedeuclideanalgorithm.com/code)
+ * ```repl
+ * :prove multinv 3 7 == 5
+ * :prove multinv 88831 319 == 167
+ * ```
+ */
+multinv : Integer -> Integer -> Integer
+multinv x m =
+    // 'b' only has a multiplicative inverse if the 'gcd' is 1
+    if gcd == 1
+    then t % m
+    else 0
+    // Get the 'gcd' and the second Bezout coefficient 't' from
+    //  the Extended Euclidean Algorithm. Note that 's' is unused.
+    //  Default values for the last four parameters are standard.
+    where (gcd, s, t) = xgcd m x 1 0 0 1
+
+/**
+ * Compute the modular inverse of x
+ *  i.e. return y such that x * y % modulus == 1
+ * Precondition: x != 0
+ * ```repl
+ * :prove modular_inverse`{32} 7492 319 == 177
+ * ```
+ */
+modular_inverse : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+modular_inverse x modulus = inverse where
+    inverse = fromInteger (multinv x' modulus')
+    x' = toInteger x
+    modulus' = toInteger modulus
+
+/**
+ * Divide two field elements: x by y
+ * ```repl
+ * :prov div`{32} 3 7492 319 == 212
+ * ```
+ */
+div : {n} (fin n, n >= 1) => [n] -> [n] -> [n] -> [n]
+div x y modulus = (x * (modular_inverse`{n} y modulus)) % modulus

--- a/spec/Common/Utils.cry
+++ b/spec/Common/Utils.cry
@@ -28,17 +28,6 @@ bool_to_bit : [1] -> Bit
 bool_to_bit b = if b == 1 then True else False
 
 /**
- * Exponentiation in the specified modulo field.
- * @see https://github.com/ethereum/c-kzg-4844/blob/main/src/common/fr.c#L93
- * ```repl
- * :prove pow`{8} 3 2 7 == 2
- * :prove pow`{32} 1 18 2 == 1
- * :prove pow`{256} 0 5 3 == 0
- */
-pow : {n} (fin n, n >= 1) => [n] -> [n] -> [n] -> [n]
-pow base exp modulus = (base ^^ exp) % modulus
-
-/**
  * Calculates the gcd and Bezout coefficients,
  *   using the Extended Euclidean Algorithm (recursive).
  *   (Source: https://extendedeuclideanalgorithm.com/code)

--- a/spec/Common/Utils.cry
+++ b/spec/Common/Utils.cry
@@ -5,6 +5,8 @@ module Common::Utils where
 
 type BYTE_WIDTH = 8
 
+type UInt64 = [64]
+
 /**
  * Convert a `Bit` to a 1-bit value.
  * We use this function because SAW cannot convert

--- a/spec/Common/Utils.cry
+++ b/spec/Common/Utils.cry
@@ -53,7 +53,7 @@ xgcd a b s1 s2 t1 t2 =
     // if r == 0, then b will be the gcd and
     //    s2, t2 the Bezout coefficients
     else if r == 0 then
-        (abs (b), fromInteger s2, fromInteger t2)
+        (abs (b), s2, t2)
     else
         xgcd b r s2 s3 t2 t3
     where

--- a/spec/Common/Utils.cry
+++ b/spec/Common/Utils.cry
@@ -26,3 +26,29 @@ bit_to_bool b = if b then 1 else 0
  */
 bool_to_bit : [1] -> Bit
 bool_to_bit b = if b == 1 then True else False
+
+/**
+ * Exponentiation in the specified modulo field.
+ *
+ * @see https://github.com/ethereum/c-kzg-4844/blob/main/src/common/fr.c#L93
+ */
+pow : {n} (fin n, n >= 1) => [n] -> [n] -> [n] -> [n]
+pow base exp modulus = (base ^^ exp) % modulus
+
+/*
+ * ===============
+ * Unit test suite
+ * ===============
+ */
+
+/**
+ * Unit tests for `pow`.
+ * ```repl
+ * :prove test_pow`{8} 3 2 7 2
+ * :prove test_pow`{32} 1 18 2 1
+ * :prove test_pow`{256} 0 5 3 0
+ * ```
+ */
+test_pow : {n} (fin n, n >= 1) => [n] -> [n] -> [n] -> [n] -> Bit
+property test_pow base exp modulus expected =
+    pow base exp modulus == expected

--- a/spec/Spec/BlsEC.cry
+++ b/spec/Spec/BlsEC.cry
@@ -1,0 +1,226 @@
+/**
+ * This module contains functions that perform ECC Point operations.
+ * These functions are specific to the BLS curve, and specifially G1.
+ *
+ * The Deneb Python specs use the py_ecc library for the same operations.
+ * This modules functions are based off of py_ecc.
+ * @see https://github.com/ethereum/py_ecc/blob/main/py_ecc/bls12_381/bls12_381_curve.py
+ */
+module Spec::BlsEC where
+
+import Common::Utils
+
+/**
+ * Size of a G1 point
+ */
+type G1Bits = 384
+
+/**
+ * Serialized G1 point
+ */
+type Bytes48 = [G1Bits]
+
+/**
+ * G1 elliptic curve point
+ */
+type G1Point =
+    { xCoord : Bytes48
+    , yCoord : Bytes48
+    }
+
+/**
+ * G1 generator
+ * @see https://github.com/ethereum/py_ecc/blob/main/py_ecc/bls12_381/bls12_381_curve.py#L35
+ */
+G1 : G1Point
+G1 =
+    { xCoord = 3685416753713387016781088315183077757961620795782546409894578378688607592378376318836054947676345821548104185464507
+    , yCoord = 1339506544944476473020471379941921221584933875938349620426543736416511423956333506472724655353366534992391756441569
+    }
+
+/**
+ * The BLS12-384 curve is defined as: y^^2 = x^^3 + 4 over the
+ *  finite field Fp, where p is the prime defined below.
+ * @see https://hackmd.io/@Wimet/S1dvK2NBh#The-Curve
+ */
+Fp : Bytes48
+Fp = 4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787
+
+/**
+ * Determines whether or not the given point is on the G1 curve.
+ * The point must satisfy the EC equation: y^^2 = x^^3 + 4
+ * ```repl
+ * :prove g1_is_valid_point G1
+ * :prove g1_is_valid_point G1_2P
+ * :prove g1_is_valid_point G1_3P
+ * :prove g1_is_valid_point G1_4P
+ * :prove g1_is_valid_point G1_5P
+ * :prove g1_is_valid_point G1_6P
+ * ```
+ */
+g1_is_valid_point : G1Point -> Bit
+g1_is_valid_point point =
+    (y^^2 - x^^3) % modulus == 4
+    where
+        x = toInteger point.xCoord
+        y = toInteger point.yCoord
+        modulus = toInteger Fp
+
+/**
+ * Double a G1 point
+ * @see https://github.com/ethereum/py_ecc/blob/main/py_ecc/bls12_381/bls12_381_curve.py#L84
+ */
+g1_double : G1Point -> G1Point
+g1_double point = newPoint where
+    x = toInteger point.xCoord
+    y = toInteger point.yCoord
+    modulus = toInteger Fp
+    m = div (3 * x^^2) (2 * y) modulus
+    newX = m^^2 - (2 * x)
+    newY = m * (x - newX) - y
+    newPoint =
+        { xCoord = fromInteger (newX % modulus)
+        , yCoord = fromInteger (newY % modulus)
+        }
+
+/**
+ * Add two G1 points
+ * @see https://github.com/ethereum/py_ecc/blob/main/py_ecc/bls12_381/bls12_381_curve.py#L95
+ */
+g1_add : G1Point -> G1Point -> G1Point
+g1_add p1 p2 =
+    if (x2 == x1) && (y2 == y1) then
+        g1_double p1
+    else
+        { xCoord = fromInteger (newX % modulus)
+        , yCoord = fromInteger (newY % modulus)
+        }
+    where
+    x1 = toInteger p1.xCoord
+    y1 = toInteger p1.yCoord
+    x2 = toInteger p2.xCoord
+    y2 = toInteger p2.yCoord
+    modulus = toInteger Fp
+    m = div (y2 - y1) (x2 - x1) modulus
+    newX = m^^2 - x1 - x2
+    newY = m * (x1 - newX) - y1
+
+/**
+ * Multiply a G1 point by a scalar
+ * @see https://github.com/ethereum/py_ecc/blob/main/py_ecc/bls12_381/bls12_381_curve.py#L114
+ */
+g1_multi : G1Point -> UInt64 -> G1Point
+g1_multi point scalar =
+    if scalar == 1 then
+        point
+    else if scalar % 2 == 0 then
+        // If scalar is even, just double
+        g1_multi (g1_double point) (scalar / 2)
+    else
+        // If scalar is odd, double and add
+        g1_add ((g1_multi (g1_double point) (scalar / 2))) point
+
+/*
+ * ===============
+ * Unit test suite
+ * ===============
+ */
+
+// All of these points were generated from: http://www.christelbach.com/eccalculator.aspx
+
+G1_2P : G1Point
+G1_2P =
+    { xCoord = 838589206289216005799424730305866328161735431124665289961769162861615689790485775997575391185127590486775437397838
+    , yCoord = 3450209970729243429733164009999191867485184320918914219895632678707687208996709678363578245114137957452475385814312
+    }
+
+G1_3P : G1Point
+G1_3P =
+    { xCoord = 1527649530533633684281386512094328299672026648504329745640827351945739272160755686119065091946435084697047221031460
+    , yCoord = 487897572011753812113448064805964756454529228648704488481988876974355015977479905373670519228592356747638779818193
+    }
+
+G1_4P : G1Point
+G1_4P =
+    { xCoord = 1940386630589042756063486004190165295069185078823041184114464346315715796897349637805088429212932248421554491972448
+    , yCoord = 3114296198575988357603748217414299058449850389627766458803888308926785677746356789015548793127623382888106859156543
+    }
+
+G1_5P : G1Point
+G1_5P =
+    { xCoord = 2601793266141653880357945339922727723793268013331457916525213050197274797722760296318099993752923714935161798464476
+    , yCoord = 3498096627312022583321348410616510759186251088555060790999813363211667535344132702692445545590448314959259020805858
+    }
+
+G1_6P : G1Point
+G1_6P =
+    { xCoord = 0x06e82f6da4520f85c5d27d8f329eccfa05944fd1096b20734c894966d12a9e2a9a9744529d7212d33883113a0cadb909
+    , yCoord = 0x17d81038f7d60bee9110d9c0d6d1102fe2d998c957f28e31ec284cc04134df8e47e8f82ff3af2e60a6d9688a4563477c
+    }
+
+/**
+ * Helper function for unit tests.
+ */
+g1_point_eq : G1Point -> G1Point -> Bit
+g1_point_eq p1 p2 =
+    (p1.xCoord == p2.xCoord) && (p1.yCoord == p2.yCoord)
+
+/**
+ * Unit tests for `g1_is_valid_point`.
+ * ```repl
+ * :prove test_g1_is_valid_point G1
+ * :prove test_g1_is_valid_point G1_2P
+ * :prove test_g1_is_valid_point G1_3P
+ * :prove test_g1_is_valid_point G1_4P
+ */
+test_g1_is_valid_point : G1Point -> Bit
+property test_g1_is_valid_point point = g1_is_valid_point point
+
+/**
+ * Unit tests for `g1_double`.
+ * ```repl
+ * :prove test_g1_double G1 G1_2P
+ * :prove test_g1_double G1_2P G1_4P
+ * :prove test_g1_double G1_3P G1_6P
+ * :prove test_g1_double (g1_double G1) G1_4P
+ * ```
+ */
+test_g1_double : G1Point -> G1Point -> Bit
+property test_g1_double p1 p2 =
+    g1_point_eq (g1_double p1) p2
+
+/**
+ * Unit tests for `g1_add`.
+ * ```repl
+ * :prove test_g1_add G1 G1 G1_2P
+ * :prove test_g1_add G1 G1_2P G1_3P
+ * :prove test_g1_add G1_2P G1 G1_3P
+ * :prove test_g1_add G1 G1_3P G1_4P
+ * :prove test_g1_add G1_3P G1 G1_4P
+ * :prove test_g1_add G1_2P G1_2P G1_4P
+ * :prove test_g1_add G1 G1_4P G1_5P
+ * :prove test_g1_add G1_4P G1 G1_5P
+ * :prove test_g1_add G1_2P G1_3P G1_5P
+ * :prove test_g1_add G1_3P G1_2P G1_5P
+ * :prove test_g1_add G1_2P G1_4P G1_6P
+ * :prove test_g1_add G1_4P G1_2P G1_6P
+ * ```
+ */
+test_g1_add : G1Point -> G1Point -> G1Point -> Bit
+property test_g1_add p1 p2 p3 =
+    g1_point_eq (g1_add p1 p2) p3
+
+/**
+ * Unit tests for `g1_multi`.
+ * ```repl
+ * :prove test_g1_multi G1 1 G1
+ * :prove test_g1_multi G1 2 G1_2P
+ * :prove test_g1_multi G1 3 G1_3P
+ * :prove test_g1_multi G1 6 G1_6P
+ * :prove test_g1_multi G1_2P 3 G1_6P
+ * :prove test_g1_multi G1_3P 2 G1_6P
+ * ```
+ */
+test_g1_multi : G1Point -> UInt64 -> G1Point -> Bit
+property test_g1_multi point scalar expected =
+    g1_point_eq (g1_multi point scalar) expected

--- a/spec/Spec/BlsHelpers.cry
+++ b/spec/Spec/BlsHelpers.cry
@@ -30,14 +30,14 @@ NEGATIVE_ONE = -1
  * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#bls_modular_inverse
  */
 bls_modular_inverse : BlsFieldElement -> BlsFieldElement
-bls_modular_inverse x = pow`{BlsFieldSize} x NEGATIVE_ONE BLS_MODULUS
+bls_modular_inverse x = modular_inverse x BLS_MODULUS
 
 /**
  * Divide two field elements: x by y
  * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#div
  */
 bls_div : BlsFieldElement -> BlsFieldElement -> BlsFieldElement
-bls_div x y = (x * (bls_modular_inverse y)) % BLS_MODULUS
+bls_div x y = div x y BLS_MODULUS
 
 /**
  * Return x to power of [0, n-1].
@@ -59,10 +59,10 @@ compute_powers x = powers where
  * Unit tests for `bls_modular_inverse`.
  * ```repl
  * :prove test_bls_modular_inverse 1 1
- * :prove test_bls_modular_inverse 2 0
- * :prove test_bls_modular_inverse 3 0x36bd0357810d2d627770d2a2a108d2a556ed06a7aaac4eabaaaaaaabaaaaaaaa
+ * :prove test_bls_modular_inverse 2 0x39f6d3a994cebea4199cec0404d0ec02a9ded2017fff2dff7fffffff80000001
+ * :prove test_bls_modular_inverse 3 0x4d491a377113a8daccd13ab0066be558e27e6d5755543d54aaaaaaaa00000001
  * ```
- * NOTE: we just chose the last value at "random"
+ * NOTE: we just chose the values at "random." Checked against: https://planetcalc.com/3298/.
  */
 test_bls_modular_inverse : BlsFieldElement -> BlsFieldElement -> Bit
 property test_bls_modular_inverse x expectedY =
@@ -71,9 +71,9 @@ property test_bls_modular_inverse x expectedY =
 /**
  * Unit tests for `bls_modular_inverse`.
  * ```repl
- * :prove test_bls_div 1 2 0
+ * :prove test_bls_div 1 2 0x39f6d3a994cebea4199cec0404d0ec02a9ded2017fff2dff7fffffff80000001
  * :prove test_bls_div 13 1 13
- * :prove test_bls_div 57 13 0x15eaf636af000c906a5000958036c58484dfe5d59d8b7c9e89d89d8ad89d89dc
+ * :prove test_bls_div 57 13 0x636268ba4b0e583e5fbfb3f1c6efb371c1e92eb51363bdf8276275f82762765b
  * ```
  * NOTE: we just chose the last value at "random"
  */

--- a/spec/Spec/BlsHelpers.cry
+++ b/spec/Spec/BlsHelpers.cry
@@ -20,9 +20,6 @@ type BlsFieldElement = [BlsFieldSize]
 BLS_MODULUS : BlsFieldElement
 BLS_MODULUS = 52435875175126190479447740508185965837690552500527637822603658699938581184513
 
-NEGATIVE_ONE : BlsFieldElement
-NEGATIVE_ONE = -1
-
 /**
  * Compute the modular inverse of x
  *  i.e. return y such that x * y % BLS_MODULUS == 1

--- a/spec/Spec/BlsHelpers.cry
+++ b/spec/Spec/BlsHelpers.cry
@@ -28,6 +28,8 @@ NEGATIVE_ONE = -1
  *  i.e. return y such that x * y % BLS_MODULUS == 1
  * Precondition: x != 0
  * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#bls_modular_inverse
+ * NOTE: Cryptol can not perform exponentiation with negative exponents,
+ *  we cannot just execute `x^^(-1) % BLS_MODULUS` like the Python spec does.
  */
 bls_modular_inverse : BlsFieldElement -> BlsFieldElement
 bls_modular_inverse x = fromInteger (modular_inverse x' modulus) where

--- a/spec/Spec/BlsHelpers.cry
+++ b/spec/Spec/BlsHelpers.cry
@@ -39,6 +39,16 @@ bls_modular_inverse x = pow`{BlsFieldSize} x NEGATIVE_ONE BLS_MODULUS
 bls_div : BlsFieldElement -> BlsFieldElement -> BlsFieldElement
 bls_div x y = (x * (bls_modular_inverse y)) % BLS_MODULUS
 
+/**
+ * Return x to power of [0, n-1].
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#compute_powers
+ * NOTE: this Cryptol function requires n >= 1, which is not the same constraint on the Python function,
+ *  whose constraint is n >= 0.
+ */
+compute_powers : {n} (fin n, width n <= 64, n >= 2) => BlsFieldElement -> [n]BlsFieldElement
+compute_powers x = powers where
+        powers = [x] # [(powers@(i-1) * x) % BLS_MODULUS | i <- [1 .. n-1]]
+
 /*
  * ===============
  * Unit test suite
@@ -70,3 +80,15 @@ property test_bls_modular_inverse x expectedY =
 test_bls_div : BlsFieldElement -> BlsFieldElement -> BlsFieldElement -> Bit
 property test_bls_div x y expected =
     bls_div x y == expected
+
+/**
+ * Unit tests for `bls_modular_inverse`.
+ * ```repl
+ * :prove test_compute_powers`{2} 13 [13, 13^^2]
+ * :prove test_compute_powers`{5} 13 [13, 13^^2, 13^^3, 13^^4, 13^^5]
+ * ```
+ * NOTE: we just chose these values at "random"
+ */
+test_compute_powers : {n} (fin n, width n <= 64, n >= 2) => BlsFieldElement -> [n]BlsFieldElement -> Bit
+property test_compute_powers x expected =
+    join (compute_powers`{n} x) == join expected

--- a/spec/Spec/BlsHelpers.cry
+++ b/spec/Spec/BlsHelpers.cry
@@ -1,0 +1,72 @@
+/**
+ * The module contains functions that perform BLS operations.
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#bls12-381-helpers
+ */
+module Spec::BlsHelpers where
+
+import Common::Utils
+
+/**
+ * BLS field elements are 256-bits long.
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#custom-types
+ */
+type BlsFieldSize = 256
+type BlsFieldElement = [BlsFieldSize]
+
+/**
+ * Specified by the consensus-specs.
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#constants
+ */
+BLS_MODULUS : BlsFieldElement
+BLS_MODULUS = 52435875175126190479447740508185965837690552500527637822603658699938581184513
+
+NEGATIVE_ONE : BlsFieldElement
+NEGATIVE_ONE = -1
+
+/**
+ * Compute the modular inverse of x
+ *  i.e. return y such that x * y % BLS_MODULUS == 1
+ * Precondition: x != 0
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#bls_modular_inverse
+ */
+bls_modular_inverse : BlsFieldElement -> BlsFieldElement
+bls_modular_inverse x = pow`{BlsFieldSize} x NEGATIVE_ONE BLS_MODULUS
+
+/**
+ * Divide two field elements: x by y
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#div
+ */
+bls_div : BlsFieldElement -> BlsFieldElement -> BlsFieldElement
+bls_div x y = (x * (bls_modular_inverse y)) % BLS_MODULUS
+
+/*
+ * ===============
+ * Unit test suite
+ * ===============
+ */
+
+/**
+ * Unit tests for `bls_modular_inverse`.
+ * ```repl
+ * :prove test_bls_modular_inverse 1 1
+ * :prove test_bls_modular_inverse 2 0
+ * :prove test_bls_modular_inverse 3 0x36bd0357810d2d627770d2a2a108d2a556ed06a7aaac4eabaaaaaaabaaaaaaaa
+ * ```
+ * NOTE: we just chose the last value at "random"
+ */
+test_bls_modular_inverse : BlsFieldElement -> BlsFieldElement -> Bit
+property test_bls_modular_inverse x expectedY =
+    bls_modular_inverse x == expectedY
+
+/**
+ * Unit tests for `bls_modular_inverse`.
+ * ```repl
+ * :prove test_bls_div 1 2 0
+ * :prove test_bls_div 13 1 13
+ * :prove test_bls_div 57 13 0x15eaf636af000c906a5000958036c58484dfe5d59d8b7c9e89d89d8ad89d89dc
+ * ```
+ * NOTE: we just chose the last value at "random"
+ */
+test_bls_div : BlsFieldElement -> BlsFieldElement -> BlsFieldElement -> Bit
+property test_bls_div x y expected =
+    bls_div x y == expected

--- a/spec/Spec/BlsHelpers.cry
+++ b/spec/Spec/BlsHelpers.cry
@@ -30,14 +30,19 @@ NEGATIVE_ONE = -1
  * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#bls_modular_inverse
  */
 bls_modular_inverse : BlsFieldElement -> BlsFieldElement
-bls_modular_inverse x = modular_inverse x BLS_MODULUS
+bls_modular_inverse x = fromInteger (modular_inverse x' modulus) where
+    x' = toInteger x
+    modulus = toInteger BLS_MODULUS
 
 /**
  * Divide two field elements: x by y
  * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#div
  */
 bls_div : BlsFieldElement -> BlsFieldElement -> BlsFieldElement
-bls_div x y = div x y BLS_MODULUS
+bls_div x y = fromInteger (div x' y' modulus) where
+    x' = toInteger x
+    y' = toInteger y
+    modulus = toInteger BLS_MODULUS
 
 /**
  * Return x to power of [0, n-1].
@@ -73,7 +78,7 @@ property test_bls_modular_inverse x expectedY =
  * ```repl
  * :prove test_bls_div 1 2 0x39f6d3a994cebea4199cec0404d0ec02a9ded2017fff2dff7fffffff80000001
  * :prove test_bls_div 13 1 13
- * :prove test_bls_div 57 13 0x636268ba4b0e583e5fbfb3f1c6efb371c1e92eb51363bdf8276275f82762765b
+ * :prove test_bls_div 57 13 0x1ac0b075a72457fcf8210a7802390a776218122813b0da27276276272762762c
  * ```
  * NOTE: we just chose the last value at "random"
  */


### PR DESCRIPTION
Add the elliptic curve operations needed to continue to implement the Deneb Python spec BLS helper functions.

(Note for reviewers: I've made an effort to make this PR more easily reviewed on a per-commit basis. Hope this helps).