### PR TITLE
Add G2 point compression and decompression

### DIFF
--- a/spec/Spec/BlsEC/G1.cry
+++ b/spec/Spec/BlsEC/G1.cry
@@ -127,6 +127,10 @@ g1_multi_optimized point scalar =
         y = fromInteger (`(Fq) - (fromZ inverse_point.yCoord))
         x = inverse_point.xCoord
 
+/**
+ * Multiply a G1 point by a scalar
+ * @see https://github.com/ethereum/py_ecc/blob/main/py_ecc/bls12_381/bls12_381_curve.py#L114
+ */
 g1_multi : G1Point -> UInt256 -> G1Point
 g1_multi point scalar =
     if scalar == 0 then G1_INFINITY
@@ -135,6 +139,18 @@ g1_multi point scalar =
         | scalar % 2 == 0 then g1_multi (g1_double point) (scalar / 2)
         // If scalar is odd, double and add
         else g1_add ((g1_multi (g1_double point) (scalar / 2))) point
+
+/**
+ * Randomize tesitng to show the two g1_multi functions are equivalent.
+ * ```repl
+ * :check g1_multis_equiv
+ * ```
+ * This takes about a minute.
+ */
+g1_multis_equiv : UInt256 -> Bit
+property g1_multis_equiv scalar = precondition ==> statement where
+    precondition = scalar < `(BLS_MODULUS)
+    statement = g1_multi G1 scalar == g1_multi_optimized G1 scalar
 
 /**
  * Determine whether or not the G1 point is a member of the subgroup.

--- a/spec/Spec/BlsEC/G1.cry
+++ b/spec/Spec/BlsEC/G1.cry
@@ -112,6 +112,12 @@ g1_add p1 p2 =
  *  Call `g1_multi` instead if `scalar == BLS_MODULUS`.
  * The optimization of running scalar multiplication on the inverse and then using the
  *  inverse of `y` is described here: https://www.mdpi.com/2227-7390/12/6/881, Section 4, second case
+ * ```repl
+ * :prove g1_multi_optimized G1 0 == G1_INFINITY
+ * :prove g1_multi_optimized G1 1 == G1
+ * :prove g1_multi_optimized G1 6 == G1_6P
+ * :prove g1_multi_optimized G1_2P 3 == g1_multi G1_3P 2
+ * ```
  */
 g1_multi_optimized : G1Point -> UInt256 -> G1Point
 g1_multi_optimized point scalar =
@@ -130,6 +136,12 @@ g1_multi_optimized point scalar =
 /**
  * Multiply a G1 point by a scalar
  * @see https://github.com/ethereum/py_ecc/blob/main/py_ecc/bls12_381/bls12_381_curve.py#L114
+ * ```repl
+ * :prove g1_multi G1 0 == G1_INFINITY
+ * :prove g1_multi G1 1 == G1
+ * :prove g1_multi G1 6 == G1_6P
+ * :prove g1_multi G1_2P 3 == g1_multi G1_3P 2
+ * ```
  */
 g1_multi : G1Point -> UInt256 -> G1Point
 g1_multi point scalar =

--- a/spec/Spec/BlsEC/G1.cry
+++ b/spec/Spec/BlsEC/G1.cry
@@ -3,7 +3,7 @@
  * These functions are specific to the BLS curve, and specifically G1.
  *
  * The Deneb Python specs use the py_ecc library for the same operations.
- * This modules functions are based off of py_ecc.
+ * This module's functions are based off of py_ecc.
  * @see https://github.com/ethereum/py_ecc/blob/main/py_ecc/bls12_381/bls12_381_curve.py
  */
 module Spec::BlsEC::G1 where

--- a/spec/Spec/BlsEC/G2.cry
+++ b/spec/Spec/BlsEC/G2.cry
@@ -14,6 +14,13 @@ import Spec::BlsEC::Field
 import Spec::BlsEC::Poly(poly_extended_euclidean)
 
 /**
+ * The order of Fq2.
+ * @see https://github.com/ethereum/py_ecc/blob/70c194edd8d1eb1457805442f0162499dbc0aac5/py_ecc/bls/constants.py#L9C1-L9C21
+ */
+FQ2_ORDER : Integer
+FQ2_ORDER = `(Fq)^^2 - 1
+
+/**
  * A G2 point is comprised of two Fq2 elements, or sets of coefficients, each of degree two.
  * Each element is comprised of a real and imaginary coeffsicient.
  */

--- a/spec/Spec/BlsEC/G2.cry
+++ b/spec/Spec/BlsEC/G2.cry
@@ -3,7 +3,7 @@
  *  G2 ECC points with coordinates in the quadratic extension field Fq2.
  *
  * The Deneb Python specs has an option to use the py_ecc library for these operations.
- * This modules functions are based off of py_ecc.
+ * This module's functions are based off of py_ecc.
  * @see https://github.com/ethereum/py_ecc/blob/main/py_ecc/bls12_381/bls12_381_curve.py
  */
 module Spec::BlsEC::G2 where

--- a/spec/Spec/BlsHelpers.cry
+++ b/spec/Spec/BlsHelpers.cry
@@ -8,6 +8,7 @@ import Common::ModArith
 import Common::Utils
 import Spec::BlsEC::Field
 import Spec::BlsEC::G1
+import Spec::BlsEC::G2
 import Spec::BlsSerde
 
 /**
@@ -97,6 +98,33 @@ bytes48_to_G1 bytes = decompress_G1 bytes
  */
 g1_to_bytes48 : G1Point -> Bytes48
 g1_to_bytes48 point = compress_G1 point
+
+/**
+ * Deserialize the G2 bytes into a G2 point
+ * @see https://github.com/ethereum/consensus-specs/blob/dcdcf25d8152cd078a9888eeddda4a550e1de009/tests/core/pyspec/eth2spec/utils/bls.py#L337
+ * ```repl
+ * :prove bytes96_to_G2 G2_POINT_AT_INFINITY == G2_INFINITY
+ * :prove bytes96_to_G2 G2_2P_COMPRESSED == G2_2P
+ * :prove bytes96_to_G2 G2_3P_COMPRESSED == G2_3P
+ * ```
+ * NOTE: We're not testing any of the invalid points since they throw runtime errors,
+ *  and Cryptol does not have a way to expect that. One can manually test to verify
+ *  these errors are thrown.
+ */
+bytes96_to_G2 : Bytes96 -> G2Point
+bytes96_to_G2 bytes = decompress_G2 bytes
+
+/**
+ * Serialize the G2 point into G2 bytes
+ * @see https://github.com/ethereum/consensus-specs/blob/dcdcf25d8152cd078a9888eeddda4a550e1de009/tests/core/pyspec/eth2spec/utils/bls.py#L315
+ * ```repl
+ * :prove g2_to_bytes96 G2_INFINITY == G2_POINT_AT_INFINITY
+ * :prove g2_to_bytes96 G2_2P == G2_2P_COMPRESSED
+ * :prove g2_to_bytes96 G2_3P == G2_3P_COMPRESSED
+ * ```
+ */
+g2_to_bytes96 : G2Point -> Bytes96
+g2_to_bytes96 point = compress_G2 point
 
 /**
  * A KZG commitment is just a G1 point

--- a/spec/Spec/BlsSerde.cry
+++ b/spec/Spec/BlsSerde.cry
@@ -59,7 +59,7 @@ G1_POINT_AT_INFINITY = 0xc0 # zero
  * :prove get_flags (0xC0 # (zero:[384-8])) == (True, True, False)
  * :prove get_flags (0xE0 # (zero:[384-8])) == (True, True, True)
  * ```
- * NOTE: `Bytes48 == [384]
+ * NOTE: `Bytes48 == [384]`
  */
 get_flags : Bytes48 -> (Bit, Bit, Bit)
 get_flags z = (c_flag, b_flag, a_flag) where

--- a/spec/Spec/BlsSerde.cry
+++ b/spec/Spec/BlsSerde.cry
@@ -162,7 +162,6 @@ property check_compression_decompress_inverse point = precondition ==> statement
     precondition = g1_is_valid_point point
     statement = decompress_G1 (compress_G1 point) == point
 
-
 /**
  * Make sure the compressed G1 point is valid, i.e. not infinity and in the subgroup.
  * @see https://github.com/ethereum/py_ecc/blob/70c194edd8d1eb1457805442f0162499dbc0aac5/py_ecc/bls/ciphersuites.py#L113

--- a/spec/Spec/BlsSerde.cry
+++ b/spec/Spec/BlsSerde.cry
@@ -37,7 +37,7 @@ POW_2_383 = 2^^383
  * Note: the name, though it is somewhat misleading, is chosen to match the Python spec.
  */
 G1_POINT_AT_INFINITY : Bytes48
-G1_POINT_AT_INFINITY = 0xc0 # (zero:[47*BYTE_WIDTH])
+G1_POINT_AT_INFINITY = 0xc0 # zero
 
 /**
  * Helper function for decompressing a G1 or G2 compresed point.

--- a/spec/Spec/BlsSerde.cry
+++ b/spec/Spec/BlsSerde.cry
@@ -9,6 +9,7 @@ import Common::ModArith
 import Common::Utils
 import Spec::BlsEC::Field
 import Spec::BlsEC::G1
+import Spec::BlsEC::G2
 
 /**
  * Size of a G1 point
@@ -243,3 +244,193 @@ G1_7P_COMPRESSED = cFlag + bFlag + aFlag + (toIntegral G1_7P.xCoord) where
     cFlag = (1 << 383) // is compressed
     bFlag = (0 << 382) // not infinity
     aFlag = (1 << 381) // because the MSB of G1_7P.yCoord is '0'
+
+/**
+ * Size of a G2 point
+ */
+type G2Bits = 768
+
+/**
+ * Serialized G2 point
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#custom-types
+ */
+type Bytes96 = [G2Bits]
+
+/**
+ * Compressed G2 point at infinity
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#constants
+ *
+ * Note: the name, though it is somewhat misleading, is chosen to match the Python spec.
+ */
+G2_POINT_AT_INFINITY : Bytes96
+G2_POINT_AT_INFINITY = 0xc0 # zero
+
+/**
+ * Test point for the decompression function `bytes96_to_G2`
+ */
+G2_2P_COMPRESSED : Bytes96
+G2_2P_COMPRESSED = cFlag + bFlag + aFlag + xReal + xImag where
+    cFlag = (1 << 767) // is compressed
+    bFlag = (0 << 766) // not infinity
+    aFlag = (1 << 765) // because the MSB of G2_2P.yCoeffs.imag is '1'
+    xReal = (toIntegral G2_2P.xCoeffs.real)
+    xImag = (toIntegral G2_2P.xCoeffs.imag) << 384
+
+/**
+ * Test point for the decompression function `bytes96_to_G2`
+ */
+G2_3P_COMPRESSED : Bytes96
+G2_3P_COMPRESSED = cFlag + bFlag + aFlag + xReal + xImag where
+    cFlag = (1 << 767) // is compressed
+    bFlag = (0 << 766) // not infinity
+    aFlag = (0 << 765) // because the MSB of G2_3P.yCoeffs.imag is '0'
+    xReal = (toIntegral G2_3P.xCoeffs.real)
+    xImag = (toIntegral G2_3P.xCoeffs.imag) << 384
+
+/**
+ * Compress the G2 point
+ *
+ * Encodes x and y coordinates in the compressed point.
+ * @see https://github.com/ethereum/py_ecc/blob/70c194edd8d1eb1457805442f0162499dbc0aac5/py_ecc/bls/point_compression.py#L145
+ *
+ * ```repl
+ * :prove compress_G2 G2_INFINITY == G2_POINT_AT_INFINITY
+ * :prove compress_G2 G2_2P == G2_2P_COMPRESSED
+ * :prove compress_G2 G2_3P == G2_3P_COMPRESSED
+ * ```
+ * The compressed point (z1, z2) has the bit order:
+ *  z1: (c_flag1, b_flag1, a_flag1, x1)
+ *  z2: (c_flag2, b_flag2, a_flag2, x2)
+ *  where
+ *  - c_flag1 is always set to 1
+ *  - b_flag1 indicates infinity when set to 1
+ *  - a_flag1 helps determine the y-coordinate when decompressing,
+ *  - a_flag2, b_flag2, and c_flag2 are always set to 0
+ */
+compress_G2 : G2Point -> Bytes96
+compress_G2 point =
+    if g2_point_eq point G2_INFINITY then
+        // Set c_flag = 1 and b_flag = 1. leave a_flag = x = 0
+        (fromInteger (POW_2_383 + POW_2_382)) # (zero:[G1Bits])
+    else
+        z1Bits + z2Bits
+    where
+        x_re = fromZ point.xCoeffs.real
+        x_im = fromZ point.xCoeffs.imag
+        y_re = fromZ point.yCoeffs.real
+        y_im = fromZ point.yCoeffs.imag
+        q = toInteger `(Fq)
+        // Record the leftmost bit of y_im to the a_flag1
+        // If y_im happens to be zero, then use the bit of y_re
+        a_flag1 = if y_im > 0 then (y_im * 2) / q else (y_re * 2) / q
+        // Imaginary part of x goes to z1, real part goes to z2
+        // c_flag1 = 1, b_flag1 = 0
+        z1 = x_im + a_flag1 * POW_2_381 + POW_2_383
+        z2 = x_re
+        z1Bits = (fromInteger z1) # (zero:[G1Bits])
+        z2Bits = (fromInteger z2)
+
+/**
+ * Decompress the G2 compressed point
+ *
+ * Recovers x and y coordinates from the compressed point.
+ * @see https://github.com/ethereum/py_ecc/blob/70c194edd8d1eb1457805442f0162499dbc0aac5/py_ecc/bls/point_compression.py#L175
+ *
+* ```repl
+ * :prove decompress_G2 G2_POINT_AT_INFINITY == G2_INFINITY
+ * :prove decompress_G2 G2_2P_COMPRESSED == G2_2P
+ * :prove decompress_G2 G2_3P_COMPRESSED == G2_3P
+ * ```
+ */
+decompress_G2 : Bytes96 -> G2Point
+decompress_G2 z =
+    // cFlag == 1 indicates the compressed form
+    // MSB should be 1
+    if ~c_flag1 then
+        error "decompress_G2: c_flag1 must be 1"
+     | b_flag1 != is_inf_pt then
+        error "b_flag1 should be 1"
+     | b_flag1 then
+        // 3 MSBs should be b110
+        if a_flag1 then
+            error "decompress_G2: a point at infinity should have a_flag1 == 0"
+        else G2_INFINITY
+     // Else, not point at infinity
+     // 3 MSBs should be b100 or b101
+     // Ensure that x1 is less than the field modulus.
+     | x1Bits >= q then
+        error "decompress_G2: x1 value should be less than field modulus"
+     // Ensure that z2 is less than the field modulus.
+     | z2 >= (fromInteger q) then
+        error "decompress_G2: z2 value should be less than field modulus"
+     // The check for y being invalid is in fq2_modular_squareroot
+     // Choose the y whose leftmost bit of the imaginary part is equal to the a_flag1
+     // If y_im happens to be zero, then use the bit of y_re
+     | (y_im > 0) && condition1 then
+        { xCoeffs = x
+        , yCoeffs = (y ~* -1)
+        }
+     | (y_im == 0) && condition2 then
+        { xCoeffs = x
+        , yCoeffs = (y ~* -1)
+        }
+     else
+        { xCoeffs = x
+        , yCoeffs = y
+        }
+    where
+    is_inf_pt = ((z1 % POW_2_381) == 0) && (z2 == 0)
+    z1 = take`{G2Bits / 2} z
+    z2 = drop`{G2Bits / 2} z
+    (c_flag1, b_flag1, a_flag1) = get_flags z1
+    x1Bits = (toInteger z1) % POW_2_381
+    x1 = fromInteger x1Bits
+    q = `(Fq)
+    x2 = fromIntegral`{Fq} z2
+    // x1 is the imaginary part, x2 is the real part
+    x = { real = x2, imag = x1}
+    y = fq2_modular_squareroot (x~^^3 ~+~ b2)
+    (y_re, y_im) = (fromZ y.real, fromZ y.imag)
+    b2 = FQ2_B2
+    condition1 = ((y_im * 2) / q) != (bit_to_integer (a_flag1))
+    condition2 = ((y_re * 2) / q) != (bit_to_integer (a_flag1))
+
+/**
+ * Given value=x, returns the value y such that y^^2 % q == x,
+ *  and errors if this is not possible. In cases where there are two solutions,
+ *  the value with higher imaginary component is favored;
+ *  if both solutions have equal imaginary component the value with higher real
+ *  component is favored.
+ * @see https://github.com/ethereum/py_ecc/blob/70c194edd8d1eb1457805442f0162499dbc0aac5/py_ecc/bls/point_compression.py#L123
+ * ```repl
+ * let y_squared = G2.xCoeffs~^^3 ~+~ FQ2_B2
+ * :prove ((fq2_modular_squareroot y_squared) ~* -1) == G2.yCoeffs
+ * ```
+ */
+fq2_modular_squareroot : Fq2 -> Fq2
+fq2_modular_squareroot value =
+    if elem check EVEN_EIGHTH_ROOTS_OF_UNITY then
+        if ((x1_im > x2_im) || ((x1_im == x2_im) && (x1_re > x2_re))) then x1 else x2
+    else
+        error "Failed to find a modular squareroot"
+    where
+        candidate_squareroot = value~^^((FQ2_ORDER + 8) / 16)
+        check = candidate_squareroot~^^2 ~/~ value
+        candidate_rou_index = (find_eighth_root_of_unity_index check) / 2
+        x1 = candidate_squareroot ~/~ (EIGHTH_ROOTS_OF_UNITY@candidate_rou_index)
+        x2 = fq2_neg x1
+        (x1_re, x1_im) = (fromZ x1.real, fromZ x1.imag)
+        (x2_re, x2_im) = (fromZ x2.real, fromZ x2.imag)
+
+FQ2_ONE = {real = 1, imag = 1}
+EIGHTH_ROOTS_OF_UNITY = [FQ2_ONE~^^((FQ2_ORDER * k) / 8) | k <- [0..7]]
+EVEN_EIGHTH_ROOTS_OF_UNITY = [EIGHTH_ROOTS_OF_UNITY@i | i <- [0, 2, 4, 6]]
+
+/**
+ * Find the index of the eighth root of unity.
+ * When this function is called, we know that we've already found an even
+ *  eighth root of unity, so we only check those.
+ */
+find_eighth_root_of_unity_index : Fq2 -> Integer
+find_eighth_root_of_unity_index value =
+    sum [if value == rou then i else 0 | rou <- EVEN_EIGHTH_ROOTS_OF_UNITY | i <- [0, 2, 4, 6]]


### PR DESCRIPTION
Along with the corresponding higher-level functions in `Spec::BlsHelpers` that call the G2 point compression and decompression. Also has some other minor fixes found along the way.