### PR TITLE
Remove trailing whitespace from cl-specs patch

### DIFF
--- a/spec/TestVectors/README.md
+++ b/spec/TestVectors/README.md
@@ -9,8 +9,8 @@ From the `spec` directory run the following:
 
 ``` bash
 % cryptol Spec/Polynomials.cry
-┏━╸┏━┓╻ ╻┏━┓╺┳╸┏━┓╻  
-┃  ┣┳┛┗┳┛┣━┛ ┃ ┃ ┃┃  
+┏━╸┏━┓╻ ╻┏━┓╺┳╸┏━┓╻
+┃  ┣┳┛┗┳┛┣━┛ ┃ ┃ ┃┃
 ┗━╸╹┗╸ ╹ ╹   ╹ ┗━┛┗━╸
 version 3.2.0 (1bcb75c)
 https://cryptol.net  :? for help
@@ -27,7 +27,7 @@ Spec::Polynomials> :dumptests result1.txt evaluate_polynomial_in_evaluation_form
 ```
 
 ## Linking to Python Spec
-A patch that adds hard coded test vectors to `consensus-specs` has been created and stored in `add-tests-to-consensus-specs.patch`. 
+A patch that adds hard coded test vectors to `consensus-specs` has been created and stored in `add-tests-to-consensus-specs.patch`.
 
 In order to run these open a copy of `consensus-specs`.
 
@@ -35,9 +35,9 @@ Ensure that you have done the necessary commands to enable running their python 
 
 ```bash
 % make install_test
-% make pyspec          
-% . venv/bin/activate    
-```  
+% make pyspec
+% . venv/bin/activate
+```
 
 Then apply the patch:
 ```bash
@@ -48,4 +48,9 @@ After patch has been applied you should be able to run the tests added an exampl
 ```bash
 % cd tests/core/pyspec
 % python -m pytest -k evaluate_polynomial_in_evaluation_form --fork deneb eth2spec
+```
+
+To revert the patch afterwards:
+```bash
+% git reset --hard origin/dev
 ```


### PR DESCRIPTION
When applying this patch, I got these warnings:

```
Applying: Adding test_evaluate_polynomial_in_evaluation_form test using the results from the Cryptol implementation.
.git/rebase-apply/patch:19: trailing whitespace.
    output1_int = 0x194f516e049d1f2636e4c8546f5f8a71893fd0bc224ce1d084c8af141c81c9fd
.git/rebase-apply/patch:4115: trailing whitespace.
    0xa560588c28684e6f353590ea1be6d6d25cf083e2f68499e7a684b95da84d1d72]
.git/rebase-apply/patch:4119: trailing whitespace.

warning: 3 lines add whitespace errors.
Applying: Add test for compute_quotient_eval_within_domain.
.git/rebase-apply/patch:23: trailing whitespace.
    output1_int = 0x01e1c8cff674198956c92807a92e9fc428894b0f238c29cdeff7655107469177
.git/rebase-apply/patch:24: trailing whitespace.
    input1_x_int = 0xb21e5c28c41639a2d2d409c07162463d1153415c1384499d2b60659421492e1e
.git/rebase-apply/patch:4120: trailing whitespace.
    0xbc5c5f38e10442c562e2b12ea9b7ff681fead4f54e95df5852418aacbd25c575]
warning: 3 lines add whitespace errors.
Applying: Add test for compute_kzg_proof_impl
.git/rebase-apply/patch:4119: trailing whitespace.
    0xbff1097dbd5bb6ddab8898eaeb7e127de0e768a69396512beed6993f20408628]
warning: 1 line adds whitespace errors.
Applying: Add test vector for compute_kzg_proof
Applying: Add kzg_proofs as well.
.git/rebase-apply/patch:38: trailing whitespace.

warning: 1 line adds whitespace errors.
Applying: Add 4 more test cases to compute_and_verify_kzg_proof, case 3,4,5 missing cryptol results currently.
.git/rebase-apply/patch:115: trailing whitespace.

warning: 1 line adds whitespace errors.
Applying: Add remaining results from Cryptol for 3,4, and 5 in compute_and_verify_kzg_proof test.
.git/rebase-apply/patch:15: trailing whitespace.
    output_proof_int_3 = 0xa5b41d5a72a125dccc9a6386ed1153e76e60021717c01ee80145ea5e47ba8dafda67e84de9bc6553597e90f3712d8c17
.git/rebase-apply/patch:18: trailing whitespace.
    0x60, 0x87, 0x6c, 0x40, 0x90, 0x80, 0xeb, 0x2f, 0x8f, 0xde])
.git/rebase-apply/patch:64: trailing whitespace.
    output_proof_int_5 = 0x8d7211a77073633351f910153a02d85a90bce876c5914e976ce9663664c05ff95ca24def8b5a6a960de2133aeca7fe70
.git/rebase-apply/patch:67: trailing whitespace.
  0x7f, 0xa0, 0xf3, 0x26, 0x79, 0x23, 0xe0, 0x79, 0xa8, 0x54])
warning: 4 lines add whitespace errors.
```

After fixing the trailing whitespace issues, it looks like:

```
Applying: Adding test_evaluate_polynomial_in_evaluation_form test using the results from the Cryptol implementation.
Applying: Add test for compute_quotient_eval_within_domain.
Applying: Add test for compute_kzg_proof_impl
Applying: Add test vector for compute_kzg_proof
Applying: Add kzg_proofs as well.
Applying: Add 4 more test cases to compute_and_verify_kzg_proof, case 3,4,5 missing cryptol results currently.
Applying: Add remaining results from Cryptol for 3,4, and 5 in compute_and_verify_kzg_proof test.
```