### PR TITLE
Add CRYPTOLPATH to example in proofs readme

### DIFF
--- a/proof/Makefile
+++ b/proof/Makefile
@@ -14,5 +14,5 @@ WORKING_DIRECTORY = $(shell pwd)
 
 $(PROOF_SCRIPTS):
 	@echo "[+] running proofs in for" $@
-# We need to tell Cryptol to search in all subdirectories of 'spec'
+	@# We need to tell Cryptol to search in all subdirectories of 'spec'
 	CRYPTOLPATH="${WORKING_DIRECTORY}/../spec/" saw $@.saw

--- a/proof/README.md
+++ b/proof/README.md
@@ -73,7 +73,7 @@ Any dependent Cryptol modules will be compiled first, and any errors will immedi
 Running the following command:
 
 ```bash
-saw permutations.saw
+CRYPTOLPATH="$(pwd)/../spec/" saw permutations.saw
 ```
 
 Results in output similar to:
@@ -94,4 +94,10 @@ Results in output similar to:
 [14:45:20.492]   variant `Symbol "reverse_bits"`
 [14:45:20.631] Checking proof obligations reverse_bits_limited ...
 [14:45:20.857] Proof succeeded! reverse_bits_limited
+```
+
+To check all available proofs, run the following Makefile command:
+
+```bash
+make proofs
 ```

--- a/proof/README.md
+++ b/proof/README.md
@@ -63,7 +63,7 @@ cp ../../c-kzg-4844/src/ckzg.bc ckzg.bc
 To execute a SAW script and check the proofs, run the following command:
 
 ```bash
-saw file.saw
+CRYPTOLPATH="$(pwd)/../spec/" saw <file>.saw
 ```
 
 Any dependent Cryptol modules will be compiled first, and any errors will immediately end the executation and be reported.
@@ -95,6 +95,8 @@ Results in output similar to:
 [14:45:20.631] Checking proof obligations reverse_bits_limited ...
 [14:45:20.857] Proof succeeded! reverse_bits_limited
 ```
+
+### Run all proofs
 
 To check all available proofs, run the following Makefile command:
 


### PR DESCRIPTION
First, specify `CRYPTOLPATH` in the example. Without this I get the following error:

```
$ saw permutations.saw
[21:24:08.112] Loading file "/Users/jtraglia/Projects/jtraglia/ckzg-eip-4844-verification/proof/permutations.saw"
[21:24:08.113] Loading file "/Users/jtraglia/Projects/jtraglia/ckzg-eip-4844-verification/proof/utils.saw"
[21:24:08.147] Stack trace:
"cryptol_load" (/Users/jtraglia/Projects/jtraglia/ckzg-eip-4844-verification/proof/permutations.saw:5:17-5:29)
Cryptol error:
[error] Could not find module Common::Utils
Searched paths:
    ../spec/Spec
    /Users/jtraglia/Projects/galois/saw/lib
    /Users/jtraglia/Projects/jtraglia/ckzg-eip-4844-verification/proof
    /Users/jtraglia/.cryptol
    /Users/jtraglia/Projects/galois/saw-1.2-macos-14-ARM64/share/cryptol
Set the CRYPTOLPATH environment variable to search more directories
```

Then, add note about `make proofs`.

Lastly, indent comment in the Makefile as a nit-fix.