### PR TITLE
Add Remaining KZG functions

### DIFF
--- a/spec/Spec/BlsHelpers.cry
+++ b/spec/Spec/BlsHelpers.cry
@@ -311,7 +311,7 @@ property test_compute_roots_of_unity =
  * Hash `data` and convert the output to a BLS scalar field element.
  * The output is not uniform over the BLS field.
  * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#hash_to_bls_field
- * Temporarily set to always return 0
+ * TODO: Temporarily set to always return 0; need to use SHA2-256
  */
 hash_to_bls_field: {n} (fin n, n >= 1) => [n][8] -> BlsFieldElement
 hash_to_bls_field data = 0

--- a/spec/Spec/BlsHelpers.cry
+++ b/spec/Spec/BlsHelpers.cry
@@ -193,6 +193,18 @@ compute_roots_of_unity order = assert (order == `n) "order must be equal to n" r
         result = compute_powers`{n} root_of_unity'
 
 /**
+ * Bytes used to encode a commitment.
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#constants
+ */
+type BYTES_PER_COMMITMENT = 48
+
+/**
+ * Bytes used to encode a proof.
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#constants
+ */
+type BYTES_PER_PROOF = 48
+
+/**
  * Bytes used to encode a BLS scalar field element.
  * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#constants
  */
@@ -217,6 +229,13 @@ bytes_to_bls_field : Bytes32 -> BlsFieldElement
 bytes_to_bls_field bytes = assert (field_element < `(BLS_MODULUS)) error_msg field_element where
     field_element = join bytes // Crytol is big endian
     error_msg = "BLS scalar field element must be less than modulus"
+
+/**
+ * Convert a BLS scalar field element to bytes.
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#bls_field_to_bytes
+ */
+bls_field_to_bytes : BlsFieldElement -> Bytes32 
+bls_field_to_bytes value = groupBy`{8} value
 
 /**
  * Perform BLS validation required by the types `KZGProof` and `KZGCommitment`.
@@ -286,3 +305,22 @@ property test_compute_roots_of_unity =
         , 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000
         , 0x73eda753299d7d47a5e80b39939ed33467baa40089fb5bfefffeffff00000001
         ]
+
+
+/**
+ * Hash `data` and convert the output to a BLS scalar field element.
+ * The output is not uniform over the BLS field.
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#hash_to_bls_field
+ * Temporarily set to always return 0
+ */
+hash_to_bls_field: {n} (fin n, n >= 1) => [n][8] -> BlsFieldElement
+hash_to_bls_field data = 0
+
+/**
+ * The two constants FIAT_SHAMIR_PROTOCOL_DOMAIN and RANDOM_CHALLENGE_KZG_BATCH_DOMAIN
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#blob
+ */
+FIAT_SHAMIR_PROTOCOL_DOMAIN : [16][8]
+FIAT_SHAMIR_PROTOCOL_DOMAIN = "FSBLOBVERIFY_V1_" : [16][8]
+RANDOM_CHALLENGE_KZG_BATCH_DOMAIN : [16][8]
+RANDOM_CHALLENGE_KZG_BATCH_DOMAIN = "RCKZGBATCH___V1_" : [16][8]

--- a/spec/Spec/KZG.cry
+++ b/spec/Spec/KZG.cry
@@ -118,16 +118,12 @@ padding_zeros value = result where
 /**
  * Return the Fiat-Shamir challenge required by the rest of the protocol.
  * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#compute_challenge
- * Discuss with Galois:
- *      -   Overflow in data = blob + degree_poly + FIAT_SHAMIR_PROTOCOL_DOMAIN_with_leading_zeros + commitment_in_bytes_with_leading_zeros
  */
 compute_challenge: Blob -> KZGCommitment -> BlsFieldElement
 compute_challenge blob commitment = result where
-    degree_poly = groupBy`{8,BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB} `(FIELD_ELEMENTS_PER_BLOB)
-    FIAT_SHAMIR_PROTOCOL_DOMAIN_with_leading_zeros = (zero : [BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB - 16][8]) # FIAT_SHAMIR_PROTOCOL_DOMAIN
-    commitment_in_bytes = groupBy`{8, 48} commitment
-    commitment_in_bytes_with_leading_zeros = (zero : [BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB - 48][8]) # commitment_in_bytes
-    data = blob + degree_poly + FIAT_SHAMIR_PROTOCOL_DOMAIN_with_leading_zeros + commitment_in_bytes_with_leading_zeros
+    degree_poly = groupBy`{8, 16} `(FIELD_ELEMENTS_PER_BLOB)
+    commitment_bytes = groupBy`{8} commitment
+    data = FIAT_SHAMIR_PROTOCOL_DOMAIN # degree_poly # blob # commitment_bytes
     result = hash_to_bls_field(data)
 
 /**
@@ -136,19 +132,11 @@ compute_challenge blob commitment = result where
  * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#compute_blob_kzg_proof
  */
 compute_blob_kzg_proof: Blob -> Bytes48 -> KZGProof
-compute_blob_kzg_proof blob commitment_bytes = 
-    assert  ((length blob) == `(BYTES_PER_BLOB)) 
-            error_msg_for_blob 
-            assert  ((length commitment_bytes) == `(BYTES_PER_COMMITMENT))
-                    error_msg_for_commitment_bytes
-                    result where
-                        error_msg_for_blob = "The length of blob must be BYTES_PER_BLOB"
-                        error_msg_for_commitment_bytes = "The length of commitment_bytes be BYTES_PER_COMMITMENT"
-                        commitment = bytes_to_kzg_commitment commitment_bytes
-                        polynomial = blob_to_polynomial blob
-                        evaluation_challenge = compute_challenge blob commitment
-                        (proof, e) = compute_kzg_proof_impl polynomial evaluation_challenge
-                        result = proof
+compute_blob_kzg_proof blob commitment_bytes = proof where
+    commitment = bytes_to_kzg_commitment commitment_bytes
+    polynomial = blob_to_polynomial blob
+    evaluation_challenge = compute_challenge blob commitment
+    (proof, e) = compute_kzg_proof_impl polynomial evaluation_challenge
 
 /**
  * Given a blob, return the KZG proof that is used to verify it against the commitment.
@@ -157,22 +145,12 @@ compute_blob_kzg_proof blob commitment_bytes =
  */
 verify_blob_kzg_proof: Blob -> Bytes48 -> Bytes48 -> Bit
 verify_blob_kzg_proof blob commitment_bytes proof_bytes =
-    assert  ((length blob) == `(BYTES_PER_BLOB)) 
-            error_msg_for_blob 
-            assert  ((length commitment_bytes) == `(BYTES_PER_COMMITMENT))
-                    error_msg_for_commitment_bytes
-                    assert  ((length proof_bytes) == `(BYTES_PER_PROOF))
-                            error_msg_for_proof_bytes
-                            result where
-                                error_msg_for_blob = "The length of blob must be BYTES_PER_BLOB"
-                                error_msg_for_commitment_bytes = "The length of commitment_bytes be BYTES_PER_COMMITMENT"
-                                error_msg_for_proof_bytes = "The length of proof_bytes must be BYTES_PER_PROOF"
-                                commitment = bytes_to_kzg_commitment commitment_bytes
-                                polynomial = blob_to_polynomial blob
-                                evaluation_challenge = compute_challenge blob commitment
-                                y = evaluate_polynomial_in_evaluation_form polynomial evaluation_challenge
-                                proof = bytes_to_kzg_proof proof_bytes
-                                result = verify_kzg_proof_impl commitment evaluation_challenge y proof
+    verify_kzg_proof_impl commitment evaluation_challenge y proof where
+        commitment = bytes_to_kzg_commitment commitment_bytes
+        polynomial = blob_to_polynomial blob
+        evaluation_challenge = compute_challenge blob commitment
+        y = evaluate_polynomial_in_evaluation_form polynomial evaluation_challenge
+        proof = bytes_to_kzg_proof proof_bytes
 
 
 /**
@@ -180,21 +158,9 @@ verify_blob_kzg_proof blob commitment_bytes proof_bytes =
  * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#verify_kzg_proof_batch
  * Add an additional assumption that k is represented with 64 bits.
  * This additional assumption is required by compute_powers
- * Discuss with Galois:
- *      -   If verify_kzg_proof_batch has the following signature 
- *              verify_kzg_proof_batch : {k, l, m, n} (fin k, fin l, fin m, fin n, k >= 2, 64 >= width k) => [k]KZGCommitment -> [l]BlsFieldElement -> [m]BlsFieldElement -> [n]KZGProof -> Bit
- *          and the following assertions are used 
- *               assert  (`(k) == `(l))
- *                      error_msg_for_commitments_zs
- *                      assert  (`(k) == `(m))
- *                              error_msg_for_commitments_ys
- *                              assert  (`(k) == `(n))
- *                                       error_msg_for_commitments_proofs
- *          then Cryptol complains that the following constraints must hold n == k. 
- *          How can we avoid this complain?
  */
 verify_kzg_proof_batch : {k} (fin k, 64 >= width k) => [k]KZGCommitment -> [k]BlsFieldElement -> [k]BlsFieldElement -> [k]KZGProof -> Bit
-verify_kzg_proof_batch commitments zs ys proofs = result where
+verify_kzg_proof_batch commitments zs ys proofs = pairing_check points where
     degree_poly = groupBy`{8,2} `(FIELD_ELEMENTS_PER_BLOB)
     num_commitments = groupBy`{8, 8} `(k)
     data_1 = RANDOM_CHALLENGE_KZG_BATCH_DOMAIN # degree_poly # num_commitments
@@ -208,26 +174,23 @@ verify_kzg_proof_batch commitments zs ys proofs = result where
                     | commitment <- commitments | y <- ys ] 
     C_minus_y_as_KZGCommitments = [ g1_to_bytes48 x | x <- C_minus_ys ]
     C_minus_y_lincomb = g1_lincomb (C_minus_y_as_KZGCommitments) (r_powers)
-    result = pairing_check [((bytes48_to_G1 proof_lincomb), (g2_negate (bytes96_to_G2 (KZG_SETUP_G2_MONOMIAL@1)))),
+    points = [((bytes48_to_G1 proof_lincomb), (g2_negate (bytes96_to_G2 (KZG_SETUP_G2_MONOMIAL@1)))),
                             ((g1_add (bytes48_to_G1 C_minus_y_lincomb) (bytes48_to_G1 proof_z_lincomb)), G2)]
 
 /**
  * Given a list of blobs and blob KZG proofs, verify that they correspond to the provided commitments.
  * Will return True if there are zero blobs/commitments/proofs.
  * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof_batch
- * Just assumpt that the input parameters have the same length k and k is represented with 64 bits.
- * The second assumption is required by verify_kzg_proof_batch.
+ * The input parameters are required to have the same length `k` and `k` is represented with 64 bits.
+ * The second assumption is also required by `verify_kzg_proof_batch`.
  */
 verify_blob_kzg_proof_batch : {k} (fin k, 64 >= width k) => [k]Blob -> [k]Bytes48 -> [k]Bytes48 -> Bit
-verify_blob_kzg_proof_batch blobs commitments_bytes proofs_bytes = result where
+verify_blob_kzg_proof_batch blobs commitments_bytes proofs_bytes = verify_kzg_proof_batch commitments evaluation_challenges ys proofs where
     commitments = [ bytes_to_kzg_commitment commitment_bytes | commitment_bytes <- commitments_bytes ]
     polynomials = [ blob_to_polynomial blob | blob <- blobs ] 
     evaluation_challenges = [ compute_challenge blob commitment | blob <- blobs | commitment <- commitments ] 
     ys = [ evaluate_polynomial_in_evaluation_form polynomial evaluation_challenge | polynomial <- polynomials | evaluation_challenge <- evaluation_challenges ]
     proofs = [ bytes_to_kzg_proof proof_bytes | proof_bytes <- proofs_bytes]
-    result = verify_kzg_proof_batch commitments evaluation_challenges ys proofs
-
-
 
 /*
  * ======================

--- a/spec/Spec/KZG.cry
+++ b/spec/Spec/KZG.cry
@@ -166,7 +166,7 @@ verify_kzg_proof_batch commitments zs ys proofs = pairing_check points where
     C_minus_ys = [ g1_add (bytes48_to_G1 commitment) (g1_multi G1 ((`(BLS_MODULUS) - y) % `(BLS_MODULUS))) 
                     | commitment <- commitments | y <- ys ] 
     C_minus_y_as_KZGCommitments = [ g1_to_bytes48 x | x <- C_minus_ys ]
-    C_minus_y_lincomb = g1_lincomb (C_minus_y_as_KZGCommitments) (r_powers)
+    C_minus_y_lincomb = g1_lincomb C_minus_y_as_KZGCommitments r_powers
     points = [((bytes48_to_G1 proof_lincomb), (g2_negate (bytes96_to_G2 (KZG_SETUP_G2_MONOMIAL@1)))),
                             ((g1_add (bytes48_to_G1 C_minus_y_lincomb) (bytes48_to_G1 proof_z_lincomb)), G2)]
 

--- a/spec/Spec/KZG.cry
+++ b/spec/Spec/KZG.cry
@@ -179,7 +179,7 @@ verify_kzg_proof_batch commitments zs ys proofs = pairing_check points where
  */
 verify_blob_kzg_proof_batch : {k} (fin k, 64 >= width k) => [k]Blob -> [k]Bytes48 -> [k]Bytes48 -> Bit
 verify_blob_kzg_proof_batch blobs commitments_bytes proofs_bytes = verify_kzg_proof_batch commitments evaluation_challenges ys proofs where
-    commitments = [ bytes_to_kzg_commitment commitment_bytes | commitment_bytes <- commitments_bytes ]
+    commitments = map bytes_to_kzg_commitment commitments_bytes
     polynomials = [ blob_to_polynomial blob | blob <- blobs ] 
     evaluation_challenges = [ compute_challenge blob commitment | blob <- blobs | commitment <- commitments ] 
     ys = [ evaluate_polynomial_in_evaluation_form polynomial evaluation_challenge | polynomial <- polynomials | evaluation_challenge <- evaluation_challenges ]

--- a/spec/Spec/KZG.cry
+++ b/spec/Spec/KZG.cry
@@ -180,7 +180,7 @@ verify_kzg_proof_batch commitments zs ys proofs = pairing_check points where
 verify_blob_kzg_proof_batch : {k} (fin k, 64 >= width k) => [k]Blob -> [k]Bytes48 -> [k]Bytes48 -> Bit
 verify_blob_kzg_proof_batch blobs commitments_bytes proofs_bytes = verify_kzg_proof_batch commitments evaluation_challenges ys proofs where
     commitments = map bytes_to_kzg_commitment commitments_bytes
-    polynomials = [ blob_to_polynomial blob | blob <- blobs ] 
+    polynomials = map blob_to_polynomial blobs 
     evaluation_challenges = [ compute_challenge blob commitment | blob <- blobs | commitment <- commitments ] 
     ys = [ evaluate_polynomial_in_evaluation_form polynomial evaluation_challenge | polynomial <- polynomials | evaluation_challenge <- evaluation_challenges ]
     proofs = [ bytes_to_kzg_proof proof_bytes | proof_bytes <- proofs_bytes]

--- a/spec/Spec/KZG.cry
+++ b/spec/Spec/KZG.cry
@@ -154,7 +154,7 @@ verify_blob_kzg_proof blob commitment_bytes proof_bytes =
  */
 verify_kzg_proof_batch : {k} (fin k, 64 >= width k) => [k]KZGCommitment -> [k]BlsFieldElement -> [k]BlsFieldElement -> [k]KZGProof -> Bit
 verify_kzg_proof_batch commitments zs ys proofs = pairing_check points where
-    degree_poly = groupBy`{8,2} `(FIELD_ELEMENTS_PER_BLOB)
+    degree_poly = groupBy`{8, 8} `(FIELD_ELEMENTS_PER_BLOB)
     num_commitments = groupBy`{8, 8} `(k)
     data_1 = RANDOM_CHALLENGE_KZG_BATCH_DOMAIN # degree_poly # num_commitments
     data_2 = [ c # z # y # p | c <- commitments | z <- zs | y <- ys | p <- proofs ]

--- a/spec/Spec/KZG.cry
+++ b/spec/Spec/KZG.cry
@@ -109,13 +109,6 @@ verify_kzg_proof commitment_bytes z_bytes y_bytes proof_bytes =
                           (bytes_to_kzg_proof proof_bytes)
 
 /**
- *  Add zeros.
- */
-padding_zeros : [16][8] -> [BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB][8]
-padding_zeros value = result where
-    result = (zero : [BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB - 16][8]) # value
-
-/**
  * Return the Fiat-Shamir challenge required by the rest of the protocol.
  * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#compute_challenge
  */

--- a/spec/Spec/KZG.cry
+++ b/spec/Spec/KZG.cry
@@ -117,7 +117,7 @@ compute_challenge blob commitment = result where
     degree_poly = groupBy`{8, 16} `(FIELD_ELEMENTS_PER_BLOB)
     commitment_bytes = groupBy`{8} commitment
     data = FIAT_SHAMIR_PROTOCOL_DOMAIN # degree_poly # blob # commitment_bytes
-    result = hash_to_bls_field(data)
+    result = hash_to_bls_field data
 
 /**
  * Given a blob, return the KZG proof that is used to verify it against the commitment.

--- a/spec/Spec/KZG.cry
+++ b/spec/Spec/KZG.cry
@@ -108,6 +108,126 @@ verify_kzg_proof commitment_bytes z_bytes y_bytes proof_bytes =
                           (bytes_to_bls_field y_bytes)
                           (bytes_to_kzg_proof proof_bytes)
 
+/**
+ *  Add zeros.
+ */
+padding_zeros : [16][8] -> [BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB][8]
+padding_zeros value = result where
+    result = (zero : [BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB - 16][8]) # value
+
+/**
+ * Return the Fiat-Shamir challenge required by the rest of the protocol.
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#compute_challenge
+ * Discuss with Galois:
+ *      -   Overflow in data = blob + degree_poly + FIAT_SHAMIR_PROTOCOL_DOMAIN_with_leading_zeros + commitment_in_bytes_with_leading_zeros
+ */
+compute_challenge: Blob -> KZGCommitment -> BlsFieldElement
+compute_challenge blob commitment = result where
+    degree_poly = groupBy`{8,BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB} `(FIELD_ELEMENTS_PER_BLOB)
+    FIAT_SHAMIR_PROTOCOL_DOMAIN_with_leading_zeros = (zero : [BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB - 16][8]) # FIAT_SHAMIR_PROTOCOL_DOMAIN
+    commitment_in_bytes = groupBy`{8, 48} commitment
+    commitment_in_bytes_with_leading_zeros = (zero : [BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB - 48][8]) # commitment_in_bytes
+    data = blob + degree_poly + FIAT_SHAMIR_PROTOCOL_DOMAIN_with_leading_zeros + commitment_in_bytes_with_leading_zeros
+    result = hash_to_bls_field(data)
+
+/**
+ * Given a blob, return the KZG proof that is used to verify it against the commitment.
+ * This method does not verify that the commitment is correct with respect to `blob`.
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#compute_blob_kzg_proof
+ */
+compute_blob_kzg_proof: Blob -> Bytes48 -> KZGProof
+compute_blob_kzg_proof blob commitment_bytes = 
+    assert  ((length blob) == `(BYTES_PER_BLOB)) 
+            error_msg_for_blob 
+            assert  ((length commitment_bytes) == `(BYTES_PER_COMMITMENT))
+                    error_msg_for_commitment_bytes
+                    result where
+                        error_msg_for_blob = "The length of blob must be BYTES_PER_BLOB"
+                        error_msg_for_commitment_bytes = "The length of commitment_bytes be BYTES_PER_COMMITMENT"
+                        commitment = bytes_to_kzg_commitment commitment_bytes
+                        polynomial = blob_to_polynomial blob
+                        evaluation_challenge = compute_challenge blob commitment
+                        (proof, e) = compute_kzg_proof_impl polynomial evaluation_challenge
+                        result = proof
+
+/**
+ * Given a blob, return the KZG proof that is used to verify it against the commitment.
+ * This method does not verify that the commitment is correct with respect to `blob`.
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof
+ */
+verify_blob_kzg_proof: Blob -> Bytes48 -> Bytes48 -> Bit
+verify_blob_kzg_proof blob commitment_bytes proof_bytes =
+    assert  ((length blob) == `(BYTES_PER_BLOB)) 
+            error_msg_for_blob 
+            assert  ((length commitment_bytes) == `(BYTES_PER_COMMITMENT))
+                    error_msg_for_commitment_bytes
+                    assert  ((length proof_bytes) == `(BYTES_PER_PROOF))
+                            error_msg_for_proof_bytes
+                            result where
+                                error_msg_for_blob = "The length of blob must be BYTES_PER_BLOB"
+                                error_msg_for_commitment_bytes = "The length of commitment_bytes be BYTES_PER_COMMITMENT"
+                                error_msg_for_proof_bytes = "The length of proof_bytes must be BYTES_PER_PROOF"
+                                commitment = bytes_to_kzg_commitment commitment_bytes
+                                polynomial = blob_to_polynomial blob
+                                evaluation_challenge = compute_challenge blob commitment
+                                y = evaluate_polynomial_in_evaluation_form polynomial evaluation_challenge
+                                proof = bytes_to_kzg_proof proof_bytes
+                                result = verify_kzg_proof_impl commitment evaluation_challenge y proof
+
+
+/**
+ * Verify multiple KZG proofs efficiently.
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#verify_kzg_proof_batch
+ * Add an additional assumption that k is represented with 64 bits.
+ * This additional assumption is required by compute_powers
+ * Discuss with Galois:
+ *      -   If verify_kzg_proof_batch has the following signature 
+ *              verify_kzg_proof_batch : {k, l, m, n} (fin k, fin l, fin m, fin n, k >= 2, 64 >= width k) => [k]KZGCommitment -> [l]BlsFieldElement -> [m]BlsFieldElement -> [n]KZGProof -> Bit
+ *          and the following assertions are used 
+ *               assert  (`(k) == `(l))
+ *                      error_msg_for_commitments_zs
+ *                      assert  (`(k) == `(m))
+ *                              error_msg_for_commitments_ys
+ *                              assert  (`(k) == `(n))
+ *                                       error_msg_for_commitments_proofs
+ *          then Cryptol complains that the following constraints must hold n == k. 
+ *          How can we avoid this complain?
+ */
+verify_kzg_proof_batch : {k} (fin k, 64 >= width k) => [k]KZGCommitment -> [k]BlsFieldElement -> [k]BlsFieldElement -> [k]KZGProof -> Bit
+verify_kzg_proof_batch commitments zs ys proofs = result where
+    degree_poly = groupBy`{8,2} `(FIELD_ELEMENTS_PER_BLOB)
+    num_commitments = groupBy`{8, 8} `(k)
+    data_1 = RANDOM_CHALLENGE_KZG_BATCH_DOMAIN # degree_poly # num_commitments
+    data_2 = [ c # z # y # p | c <- commitments | z <- zs | y <- ys | p <- proofs ]
+    data = data_1 # (groupBy`{8} (join data_2))
+    r = hash_to_bls_field data
+    r_powers = compute_powers`{k} r 
+    proof_lincomb = g1_lincomb proofs r_powers
+    proof_z_lincomb = g1_lincomb proofs ([z * r_power | z <- zs | r_power <- r_powers])
+    C_minus_ys = [ g1_add (bytes48_to_G1 commitment) (g1_multi G1 ((`(BLS_MODULUS) - y) % `(BLS_MODULUS))) 
+                    | commitment <- commitments | y <- ys ] 
+    C_minus_y_as_KZGCommitments = [ g1_to_bytes48 x | x <- C_minus_ys ]
+    C_minus_y_lincomb = g1_lincomb (C_minus_y_as_KZGCommitments) (r_powers)
+    result = pairing_check [((bytes48_to_G1 proof_lincomb), (g2_negate (bytes96_to_G2 (KZG_SETUP_G2_MONOMIAL@1)))),
+                            ((g1_add (bytes48_to_G1 C_minus_y_lincomb) (bytes48_to_G1 proof_z_lincomb)), G2)]
+
+/**
+ * Given a list of blobs and blob KZG proofs, verify that they correspond to the provided commitments.
+ * Will return True if there are zero blobs/commitments/proofs.
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof_batch
+ * Just assumpt that the input parameters have the same length k and k is represented with 64 bits.
+ * The second assumption is required by verify_kzg_proof_batch.
+ */
+verify_blob_kzg_proof_batch : {k} (fin k, 64 >= width k) => [k]Blob -> [k]Bytes48 -> [k]Bytes48 -> Bit
+verify_blob_kzg_proof_batch blobs commitments_bytes proofs_bytes = result where
+    commitments = [ bytes_to_kzg_commitment commitment_bytes | commitment_bytes <- commitments_bytes ]
+    polynomials = [ blob_to_polynomial blob | blob <- blobs ] 
+    evaluation_challenges = [ compute_challenge blob commitment | blob <- blobs | commitment <- commitments ] 
+    ys = [ evaluate_polynomial_in_evaluation_form polynomial evaluation_challenge | polynomial <- polynomials | evaluation_challenge <- evaluation_challenges ]
+    proofs = [ bytes_to_kzg_proof proof_bytes | proof_bytes <- proofs_bytes]
+    result = verify_kzg_proof_batch commitments evaluation_challenges ys proofs
+
+
 
 /*
  * ======================

--- a/spec/Spec/Polynomials.cry
+++ b/spec/Spec/Polynomials.cry
@@ -55,11 +55,17 @@ evaluate_polynomial_in_evaluation_form polynomial z =
             evaluation = result * r * inverse_width
 
 /**
+ * The constant BYTES_PER_BLOB is the number of bytes in a blob.
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#constants
+ */
+type BYTES_PER_BLOB = BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB
+
+/**
  * The BLS basic data blob
  * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#custom-types
  * Also @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#blob
  */
-type Blob = [BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB][8]
+type Blob = [BYTES_PER_BLOB][8]
 
 /**
  * Convert a blob to list of BLS field scalars.

--- a/spec/Spec/README.md
+++ b/spec/Spec/README.md
@@ -19,7 +19,6 @@ The table below indicates the Cryptol module where the corresponding Deneb funct
 | validate_kzg_g1                        | Spec::BlsHelpers    |
 | bytes_to_kzg_commitment                | Spec::BlsHelpers    |
 | bytes_to_kzg_proof                     | Spec::BlsHelpers    |
-| compute_challenge                      | Not yet implemented |
 | g1_lincomb                             | Spec::BlsHelpers    |
 | compute_powers                         | Spec::BlsHelpers    |
 | compute_roots_of_unity                 | Spec::BlsHelpers    |
@@ -28,13 +27,15 @@ The table below indicates the Cryptol module where the corresponding Deneb funct
 | blob_to_kzg_commitment                 | Spec::KZG           |
 | verify_kzg_proof                       | Spec::KZG           |
 | verify_kzg_proof_impl                  | Spec::KZG           |
-| verify_kzg_proof_batch                 | Not yet implemented |
+| verify_kzg_proof_batch                 | Spec::KZG           |
+| compute_challenge                      | Spec::KZG           |
 | compute_kzg_proof                      | Spec::KZG           |
 | compute_kzg_proof_impl                 | Spec::KZG           |
 | compute_quotient_eval_within_domain    | Spec::KZG           |
-| compute_blob_kzg_proof                 | Not yet implemented |
-| verify_blob_kzg_proof                  | Not yet implemented |
-| verify_blob_kzg_proof_batch            | Not yet implemented |
+| compute_blob_kzg_proof                 | Spec::KZG           |
+| verify_blob_kzg_proof                  | Spec::KZG           |
+| verify_blob_kzg_proof_batch            | Spec::KZG           |
+
 
 ## Tests
 

--- a/spec/Spec/TrustedSetup.cry
+++ b/spec/Spec/TrustedSetup.cry
@@ -3,6 +3,8 @@
  *  - KZG_SETUP_G1_MONOMIAL
  *  - KZG_SETUP_G1_LAGRANGE
  *  - KZG_SETUP_G2_MONOMIAL
+ * and the type
+ *  - KZG_SETUP_G2_LENGTH
  * @see https://github.com/ethereum/consensus-specs/blob/dev/presets/minimal/trusted_setups/trusted_setup_4096.json
  */
 module Spec::TrustedSetup where
@@ -8218,10 +8220,15 @@ KZG_SETUP_G1_LAGRANGE = [
     0x825a6f586726c68d45f00ad0f5a4436523317939a47713f78fd4fe81cd74236fdac1b04ecd97c2d0267d6f4981d7beb1
     ]
 
+/** 
+ * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#trusted-setup
+ */
+type KZG_SETUP_G2_LENGTH = 65
+
 /**
  * @see https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#trusted-setup
  */
-KZG_SETUP_G2_MONOMIAL : [65]Bytes96
+KZG_SETUP_G2_MONOMIAL : [KZG_SETUP_G2_LENGTH]Bytes96
 KZG_SETUP_G2_MONOMIAL = [
     0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8,
     0xb5bfd7dd8cdeb128843bc287230af38926187075cbfbefa81009a2ce615ac53d2914e5870cb452d2afaaab24f3499f72185cbfee53492714734429b7b38608e23926c911cceceac9a36851477ba4c60b087041de621000edc98edada20c1def2,


### PR DESCRIPTION
Add the remaining KZG and BlsHelper functions from the Deneb Python spec.

```
BlsHelper:
- bls_field_to_bytes
- hash_to_field (this is just a stub; needs to point to SHA2-256)
KZG:
- verify_kzg_proof_batch
- compute_blob_kzg_proof
- verify_blob_kzg_proof
- verify_blob_kzg_proof_batch
```